### PR TITLE
 Limit deliveries to 1000 and add status filter flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .nyc_output
+node_modules

--- a/test/commands/webhooks/deliveries/index.js
+++ b/test/commands/webhooks/deliveries/index.js
@@ -13,9 +13,11 @@ describe('heroku webhooks:deliveries', function () {
   })
 
   it('# lists deliveries', function () {
-    let mock = nock('https://api.heroku.com')
+    let mock = nock('https://api.heroku.com', {
+      reqheaders: {range: 'seq ..; order=desc,max=1000'},
+    })
     .get('/apps/example/webhook-deliveries')
-    .reply(200, [{
+    .reply(206, [{
       id: '66666666-6666-6666-6666-666666666666',
       event: {
         id: '55555555-5555-5555-5555-555555555555',
@@ -46,7 +48,7 @@ describe('heroku webhooks:deliveries', function () {
       num_attempts: 4,
       created_at: '2017-08-17T20:22:37Z',
       next_attempt_at: '2017-08-17T20:22:39Z',
-    }])
+    }], {'next-range': 'id 99999999-9999-9999-9999-999999999999'})
 
     return certs.run(['--app', 'example']).then(function () {
       mock.done()
@@ -57,6 +59,65 @@ describe('heroku webhooks:deliveries', function () {
 99999999-9999-9999-9999-999999999999  2017-08-17T20:22:37Z  retrying  api:build  notify  4         401   Foobar  2017-08-17T20:22:39Z
 66666666-6666-6666-6666-666666666666  2017-08-17T20:22:38Z  pending   api:build  notify  4
 `)
+    })
+  })
+
+  it('# lists deliveries by state', function () {
+    let mock = nock('https://api.heroku.com', {
+      reqheaders: {range: 'seq ..; order=desc,max=1000'},
+    })
+    .get('/apps/example/webhook-deliveries?eq[status]=pending')
+    .reply(206, [{
+      id: '66666666-6666-6666-6666-666666666666',
+      event: {
+        id: '55555555-5555-5555-5555-555555555555',
+        include: 'api:build',
+      },
+      webhook: {
+        id: '44444444-4444-4444-4444-444444444444',
+        level: 'notify',
+      },
+      status: 'pending',
+      num_attempts: 4,
+      created_at: '2017-08-17T20:22:38Z',
+    }])
+
+    return certs.run(['--app', 'example', '--status', 'pending']).then(function () {
+      mock.done()
+      expect(cli.stderr).to.equal('')
+      expect(cli.stdout).to.equal(
+        `Delivery ID                           Created               Status   Include    Level   Attempts  Code  Error  Next Attempt
+────────────────────────────────────  ────────────────────  ───────  ─────────  ──────  ────────  ────  ─────  ────────────
+66666666-6666-6666-6666-666666666666  2017-08-17T20:22:38Z  pending  api:build  notify  4
+`)
+    })
+  })
+
+  it('# lists 1000 deliveries', function () {
+    let delivery = {
+      id: '66666666-6666-6666-6666-666666666666',
+      event: {
+        id: '55555555-5555-5555-5555-555555555555',
+        include: 'api:build',
+      },
+      webhook: {
+        id: '44444444-4444-4444-4444-444444444444',
+        level: 'notify',
+      },
+      status: 'pending',
+      num_attempts: 4,
+      created_at: '2017-08-17T20:22:38Z',
+    }
+
+    let mock = nock('https://api.heroku.com', {
+      reqheaders: {range: 'seq ..; order=desc,max=1000'},
+    })
+    .get('/apps/example/webhook-deliveries')
+    .reply(206, new Array(1000).fill().map(() => delivery))
+
+    return certs.run(['--app', 'example']).then(function () {
+      mock.done()
+      expect(cli.stderr).to.equal(' ▸    Only showing the 1000 most recent deliveries\n ▸    It is possible to filter deliveries by using the --status flag\n')
     })
   })
 


### PR DESCRIPTION
When working on the webhooks dashboard feature we found an app with 40,000 plus deliveries and it chokes horribly on the `webhooks:deliveries` command and would burn through a users rate limit quickly.  This does server side sorting and turns off the ranged fetch and limits to the most recent 1000.  We also add a status flag so they can find failed deliveries even if they are not in the last 1000.